### PR TITLE
allow getState to be passed to action

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,6 @@ export function asyncActionCreator(type, config) {
 
   return payload => (dispatch, ...args) => {
     const action = config.action || (isNode ? server : client);
-    args.unshift(payload);
     dispatch({type, payload});
     return action(payload, dispatch, ...args).then(
         response => dispatch({

--- a/src/index.js
+++ b/src/index.js
@@ -17,10 +17,10 @@ export function asyncActionCreator(type, config) {
   if (typeof config === 'function') config = {action: config}; // eslint-disable-line no-param-reassign
   const {client, server, schema} = config;
 
-  return payload => dispatch => {
+  return payload => (dispatch, getState) => {
     const action = config.action || (isNode ? server : client);
     dispatch({type, payload});
-    return action(payload).then(
+    return action(payload, getState).then(
         response => dispatch({
           type: `${type}_${SUCCESS}`,
           payload,

--- a/src/index.js
+++ b/src/index.js
@@ -17,12 +17,11 @@ export function asyncActionCreator(type, config) {
   if (typeof config === 'function') config = {action: config}; // eslint-disable-line no-param-reassign
   const {client, server, schema} = config;
 
-  return payload => (...args) => {
-    const dispatch = args[0];
+  return payload => (dispatch, ...args) => {
     const action = config.action || (isNode ? server : client);
     args.unshift(payload);
     dispatch({type, payload});
-    return action(...args).then(
+    return action(payload, dispatch, ...args).then(
         response => dispatch({
           type: `${type}_${SUCCESS}`,
           payload,

--- a/src/index.js
+++ b/src/index.js
@@ -17,10 +17,12 @@ export function asyncActionCreator(type, config) {
   if (typeof config === 'function') config = {action: config}; // eslint-disable-line no-param-reassign
   const {client, server, schema} = config;
 
-  return payload => (dispatch, getState) => {
+  return payload => (...args) => {
+    const dispatch = args[0];
     const action = config.action || (isNode ? server : client);
+    args.unshift(payload);
     dispatch({type, payload});
-    return action(payload, getState).then(
+    return action(...args).then(
         response => dispatch({
           type: `${type}_${SUCCESS}`,
           payload,


### PR DESCRIPTION
Fixes #1 
Allows access to redux-thunk's getState method within the asyncActionCreator function.