### PR TITLE
Update presets option in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015"],
+  "presets": ["react-native"],
   "env": {
     "test": {
       "plugins": ["istanbul"]


### PR DESCRIPTION
<img width="641" alt="screen shot 2018-04-25 at 3 11 01 pm" src="https://user-images.githubusercontent.com/7763904/39268023-a2dc5c8c-489c-11e8-8777-c816ebc1f191.png">
This pull request fixes the issue where the Metro bundler in React Native v0.55.3 couldn't find the Babel preset "es2015" and thus fail to bundle JavaScript files. Therefore, the presets option in .babelrc has been updated to "react-native" in order to match the .babelrc that ships with the latest React Native release.